### PR TITLE
Make `br` a constant instead of a function

### DIFF
--- a/examples/counters/index.ts
+++ b/examples/counters/index.ts
@@ -1,18 +1,17 @@
-import {Do} from "jabz/monad";
+import {go} from "jabz/monad";
 
 import * as B from "hareactive/Behavior";
 import {Behavior, stepper, scan} from "hareactive/Behavior";
 import {
-  Stream, snapshotWith, merge, map, mergeList, switchStream, scanS
+  Stream, merge, map, mergeList, switchStream, scanS
 } from "hareactive/Stream";
 import {Now, sample} from "hareactive/Now";
 
 import {Component, component} from "../../src/component";
 import {runMain} from "../../src/bootstrap"
 import {list} from "../../src/dom-builder";
-import {span, input, br as Br, text, button, div, h1} from "../../src/elements";
+import {span, input, br, text, button, div, h1} from "../../src/elements";
 
-const br = Br();
 const add = (n: number, m: number) => n + m;
 const append = <A>(a: A, as: A[]) => as.concat([a]);
 const apply = <A>(f: (a: A) => A, a: A) => f(a);
@@ -36,15 +35,15 @@ type CounterOut = {
 
 const counter = (id: Id) => component<CounterModelOut, CounterViewOut, CounterOut>({
   model: ({incrementClick, decrementClick, deleteClick}) =>
-    Do(function*(): Iterator<Now<any>> {
+    go(function*(): Iterator<Now<any>> {
       const increment = incrementClick.mapTo(1);
       const decrement = decrementClick.mapTo(-1);
       const deleteS = deleteClick.mapTo(id);
       const count = yield sample(scan(add, 0, merge(increment, decrement)));
       return Now.of([[count], {count, deleteS}]);
     }),
-  view: ([count]) => Do(function*() {
-    const {children: divStreams} = yield div(Do(function*() {
+  view: ([count]) => go(function*() {
+    const {children: divStreams} = yield div(go(function*() {
       yield text("Counter ");
       yield text(count);
       yield text(" ");
@@ -68,7 +67,7 @@ type ToModel = {
 };
 
 const main = component<ToView, ToModel, {}>({
-  model: ({addCounter, listOut}) => Do(function*(): Iterator<Now<any>> {
+  model: ({addCounter, listOut}) => go(function*(): Iterator<Now<any>> {
     const removeIdB = listOut.map((l) => mergeList(l.map(o => o.deleteS)));
     const removeCounterIdFn =
       switchStream(removeIdB).map(id => arr => arr.filter(i => i !== id));
@@ -82,7 +81,7 @@ const main = component<ToView, ToModel, {}>({
       yield sample(scan(apply, [0,1,2], modifications));
     return Now.of([[counterIds], {}]);
   }),
-  view: ([counterIds]) => Do(function*(): Iterator<Component<any>> {
+  view: ([counterIds]) => go(function*(): Iterator<Component<any>> {
     yield h1("Counters");
     const {click: addCounter} = yield button("Add counter")
     yield text(" ");

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -37,10 +37,10 @@ const main = component<ToView, ViewOut, {}>({
   view: ([validB, lengthB]) => go(function*(): Iterator<Component<any>> {
     yield span("Please enter an email address: ");
     const {inputValue: emailB} = yield input();
-    yield br();
+    yield br;
     yield text("The address is ");
     yield text(validB.map(t => t ? "valid" : "invalid"));
-    yield br();
+    yield br;
     const {click: calcLength} = yield button("Calculate length");
     yield span(" The length of the email is ");
     yield text(lengthB);

--- a/examples/zip-codes/index.ts
+++ b/examples/zip-codes/index.ts
@@ -64,7 +64,7 @@ const view = ([status]: ToView) => go(function*(): Iterator<Component<any>> {
   yield span("Please type a valid US zip code: ");
   const {inputValue: zipCode, input: zipInput} =
     yield input({props: {placeholder: "Zip code"}});
-  yield br();
+  yield br;
   yield text(status);
   return Component.of({zipCode, zipInput});
 });

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -10,7 +10,7 @@ export const input = e("input", { behaviors: [
   ["input", "inputValue", (evt: any) => evt.target.value, ""]
 ]});
 
-export const br = e("br");
+export const br = e("br")();
 export const span = e("span");
 export const h1 = e("h1");
 export const div = e("div");


### PR DESCRIPTION
So that instead of `br()` one uses `br`.

This seems very minor but I think it is somewhat important. A function that takes no arguments looks impure in the same way that a function with return type `void` indicates impurity. Since a pure function can do nothing but return a value based on it's input, if it doesn't take any arguments it must either be impure or always return the exact same value. In the latter case it can simply be made into a constant.

`br` took some optional arguments but they didn't make sense for a `br` elements anyway so we loose nothing by making it a constant.