### PR TITLE
Wrapper elments

### DIFF
--- a/examples/counters/index.ts
+++ b/examples/counters/index.ts
@@ -5,7 +5,7 @@ import {
 } from "hareactive/stream";
 import {Now, sample} from "hareactive/now";
 
-import {Component, component, list, dynamic, text, runMain, elements} from "../../";
+import {Component, component, list, dynamic, text, runMain, elements} from "../../src";
 const {span, input, br, button, div, h1} = elements;
 
 const add = (n: number, m: number) => n + m;
@@ -40,7 +40,7 @@ const counter = (id: Id) => component<CounterModelOut, CounterViewOut, CounterOu
     return [{count}, {count, deleteS}];
   },
   function* counterView({count}) {
-    const {children: divStreams} = yield div(function*() {
+    return yield div(function*() {
       yield text("Counter ");
       yield dynamic(count);
       yield text(" ");
@@ -52,7 +52,6 @@ const counter = (id: Id) => component<CounterModelOut, CounterViewOut, CounterOu
       yield br;
       return {incrementClick, decrementClick, deleteClick};
     });
-    return divStreams;
   }
 );
 
@@ -82,7 +81,7 @@ function* mainModel({addCounter, listOut}: ToModel): Iterator<Now<any>> {
 
 function* mainView({counterIds}: ToView): Iterator<Component<any>> {
   yield h1("Counters");
-  const {click: addCounter} = yield button("Add counter")
+  const {click: addCounter} = yield button("Add counter");
   yield br;
   yield br;
   const listOut = yield list(counter, (n: number) => n, counterIds);

--- a/examples/fahrenheit-celsius/index.ts
+++ b/examples/fahrenheit-celsius/index.ts
@@ -2,7 +2,7 @@ import {Behavior, stepper} from "hareactive/behavior";
 import {Stream, merge} from "hareactive/stream";
 import {Now} from "hareactive/now";
 
-import {Component, component, runMain, elements} from "../../";
+import {Component, component, runMain, elements} from "../../src";
 const {input, div, label} = elements;
 
 type ToView = {
@@ -26,11 +26,11 @@ const main = component<ToView, ViewOut, {}>(
     return Now.of([{celsius, fahren}, {}]);
   },
   function* view({celsius, fahren}: ToView) {
-    const {children: {input: fahrenInput}} = yield div(function*() {
+    const {input: fahrenInput} = yield div(function*() {
       yield label("Fahrenheit");
       return yield input({props: {value: fahren}});
     });
-    const {children: {input: celsiusInput}} = yield div(function*() {
+    const {input: celsiusInput} = yield div(function*() {
       yield label("Celcious");
       return yield input({props: {value: celsius}});
     });

--- a/src/dom-builder.ts
+++ b/src/dom-builder.ts
@@ -13,6 +13,7 @@ export type StreamDescription<A> = [string, string, (evt: any) => A]
 export type BehaviorDescription<A> = [string, string, (evt: any) => A, A];
 
 export type Properties = {
+  wrapper?: boolean,
   streams?: StreamDescription<any>[],
   behaviors?: BehaviorDescription<any>[],
   style?: CSSStyleType,
@@ -109,7 +110,12 @@ class CreateDomNow<A> extends Now<A> {
       }
     }
     if (this.children !== undefined) {
-      output.children = runComponentNow(elm, toComponent(this.children));
+      const childOutput = runComponentNow(elm, toComponent(this.children));
+      if (this.props.wrapper === true) {
+        output = childOutput;
+      } else {
+        output.children = childOutput;
+      }
     }
     this.parent.appendChild(elm);
     return output;

--- a/src/dom-builder.ts
+++ b/src/dom-builder.ts
@@ -152,6 +152,8 @@ function parseCSSTagname(cssTagName: string): [string, Properties] {
 export type CreateElementFunc<A> = (newPropsOrChildren?: Child | Properties, newChildren?: Properties) => Component<A>;
 
 export function e<A>(tagName: string, props: Properties = {}): CreateElementFunc<A> {
+  const [parsedTagName, tagProps] = parseCSSTagname(tagName);
+  props = merge(props, tagProps);
   function createElement(): Component<any>;
   function createElement(props: Properties): Component<A>;
   function createElement(child: Child): Component<A>;
@@ -161,7 +163,7 @@ export function e<A>(tagName: string, props: Properties = {}): CreateElementFunc
       return new Component((p) => new CreateDomNow<A>(p, tagName, props, newPropsOrChildren));
     } else {
       const newProps = merge(props, newPropsOrChildren);
-      return new Component((p) => new CreateDomNow<A>(p, tagName, newProps, newChildrenOrUndefined));
+      return new Component((p) => new CreateDomNow<A>(p, parsedTagName, newProps, newChildrenOrUndefined));
     }
   }
   return createElement;

--- a/src/dom-builder.ts
+++ b/src/dom-builder.ts
@@ -151,28 +151,17 @@ function parseCSSTagname(cssTagName: string): [string, Properties] {
 
 export type CreateElementFunc<A> = (newPropsOrChildren?: Child | Properties, newChildren?: Properties) => Component<A>;
 
-export function e<A>(tagName: string): CreateElementFunc<A>;
-export function e<A>(tagName: string, children: Child): CreateElementFunc<A>;
-export function e<A>(tagName: string, props: Properties): CreateElementFunc<A>;
-export function e<A>(tagName: string, props: Properties, children: Child): CreateElementFunc<A>;
-export function e<A>(tagName: string, propsOrChildren?: Properties | Child, children?: Child): CreateElementFunc<A> {
-  
-  const [parsedTagName, tagProps] = parseCSSTagname(tagName);
-    
+export function e<A>(tagName: string, props: Properties = {}): CreateElementFunc<A> {
   function createElement(): Component<any>;
   function createElement(props: Properties): Component<A>;
-  function createElement(aChildren: Child): Component<A>;
+  function createElement(child: Child): Component<A>;
   function createElement(props: Properties, bChildren: Child): Component<A>;
   function createElement(newPropsOrChildren?: Properties | Child, newChildrenOrUndefined?: Child): Component<A> {
     if (newChildrenOrUndefined === undefined && isChild(newPropsOrChildren)) {
-      const newProps = merge(tagProps,  propsOrChildren);
-      return new Component((p) => new CreateDomNow<A>(p, parsedTagName, newProps, newPropsOrChildren));
-    } else if (isChild(propsOrChildren)) {
-      const newProps = merge(tagProps, newPropsOrChildren);
-      return new Component((p) => new CreateDomNow<A>(p, parsedTagName, newProps, newChildrenOrUndefined || propsOrChildren));
+      return new Component((p) => new CreateDomNow<A>(p, tagName, props, newPropsOrChildren));
     } else {
-      const newProps = merge(tagProps, propsOrChildren, newPropsOrChildren);
-      return new Component((p) => new CreateDomNow<A>(p, parsedTagName, newProps, newChildrenOrUndefined || children));
+      const newProps = merge(props, newPropsOrChildren);
+      return new Component((p) => new CreateDomNow<A>(p, tagName, newProps, newChildrenOrUndefined));
     }
   }
   return createElement;

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -17,16 +17,16 @@ export const input = e("input", {
 });
 
 export const br      = e("br")();
-export const span    = e("span");
+export const span    = e("span", {wrapper: true});
+export const div     = e("div", {wrapper: true});
+export const p       = e("p", {wrapper: true});
 export const h1      = e("h1");
-export const div     = e("div");
 export const label   = e("label");
 export const ul      = e("ul");
 export const li      = e("li");
 export const a       = e("a");
-export const p       = e("p");
 export const section = e("section");
-export const button  = e("button", { streams: [
+export const button  = e("button", {streams: [
   ["click", "click", id]
 ]});
 

--- a/test/dom-builder.spec.ts
+++ b/test/dom-builder.spec.ts
@@ -46,22 +46,6 @@ describe("dom-builder: e()", () => {
 
   describe("children", () => {
 
-    it("default text", () => {
-      const spanFac = e("span", "default text");
-      const spanC = spanFac();
-      const div = document.createElement("div");
-      runComponentNow(div, spanC);
-      assert.strictEqual(div.children[0].textContent, "default text");
-    });
-
-    it("override text", () => {
-      const spanFac = e("span", "default text");
-      const spanC = spanFac("override text");
-      const div = document.createElement("div");
-      runComponentNow(div, spanC);
-      assert.strictEqual(div.children[0].textContent, "override text");
-    });
-
     it("nested", () => {
       const spanFac = e("span");
       const h1Fac = e("h1");
@@ -107,18 +91,17 @@ describe("dom-builder: e()", () => {
   describe("properties and children combinations", () => {
 
     it("e(children)         fac(props) ", () => {
-      const spanFac = e("span", "default text");
+      const spanFac = e("span");
       const spanC = spanFac({style: {
         backgroundColor: "red"
       }});
       const div = document.createElement("div");
       runComponentNow(div, spanC);
-      assert.strictEqual(div.children[0].textContent, "default text");
       assert.strictEqual((<HTMLElement>div.children[0]).style.backgroundColor, "red");
     });
 
     it("e(children)         fac(props, children) ", () => {
-      const spanFac = e("span", "default text");
+      const spanFac = e("span");
       const spanC = spanFac({style: {
         backgroundColor: "red"
       }}, "override text");


### PR DESCRIPTION
Add support for wrapper elements that by default bubbles their childs output up.

Also, `e` doesn't handle children on the first invocation and thus don't need overloads.