### PR TITLE
Add actions that triggers callbacks

### DIFF
--- a/examples/todo/src/Item.ts
+++ b/examples/todo/src/Item.ts
@@ -116,7 +116,7 @@ export default function item(toggleAll: Stream<boolean>, {name: initialName, id}
           class: "edit",
 	  props: {value: taskName},
           output: {input: "newNameInput", keyup: "nameKeyup", blur: "nameBlur"},
-	  action: {focus: focusInput}
+	  actions: {focus: focusInput}
         })
       ]));
     }

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -6,6 +6,9 @@ import {CSSStyleType} from "./CSSStyleType";
 function id<A>(a: A): A { return a; };
 
 export const input = e("input", {
+  actionDefinitions: {
+    focus: (element) => element.focus()
+  },
   behaviors: [
     ["input", "inputValue", (evt: any) => evt.target.value, ({value}: HTMLInputElement) => value]
   ],


### PR DESCRIPTION
This expands on the actions feature to make it more powerful.

Actions now have to be defined with a `actionDefinitions` property. The property is a key-value object where each key is the action name and the value is a callback. The callback receives the actual DOM element and the latest value from a stream/behavior.

Example

```javascript
export const input = e("input", {
  actionDefinitions: {
    focus: (element) => element.focus()
  }
});
```

Which can be used like this:

```
input({actions: {focus: triggerFocusS}});
```

If used with behaviors `actionDefinitions` is still used to create the action.

```typescript
const canvas = e("canvas", {
  actionDefinitions: {
    render: (elm: HTMLCanvasElement, image: Image) => {
      const ctx = elm.getContext("2d");
      // do rendering
  }
});
```

But the behavior to trigger the action has to be given through the `setters` property.

```typescript
canvas({
  props: { width: 600, height: 600 },
  setters: { render: imageB }
})
```

`actions` and `setters` can currently not be combined because if a placeholder is given in the combined object then it is impossible to know if it should be listened to as a stream or as a behavior.

This is rather ugly IMO. I hope we can figure out a prettier way to implement the feature.